### PR TITLE
支持clang编译，重构dockerfile结构

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,21 +2,33 @@ FROM ubuntu:xenial
 
 MAINTAINER ngot "https://github.com/ngot"
 
-RUN apt-get update && \
-    apt-get -y --no-install-recommends install make cmake xz-utils git clang-6.0 g++-5-mips-linux-gnu g++-5-mips64-linux-gnuabi64 g++-5-powerpc-linux-gnu g++-5-powerpc64-linux-gnu g++-5-arm-linux-gnueabihf g++-5-aarch64-linux-gnu && \
-    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 999 && \
-    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-6.0 999 && \
-    update-alternatives --install /usr/bin/mips-linux-gnu-gcc mips-linux-gnu-gcc /usr/bin/mips-linux-gnu-gcc-5 999 && \
-	update-alternatives --install /usr/bin/mips-linux-gnu-g++ mips-linux-gnu-g++ /usr/bin/mips-linux-gnu-g++-5 999 && \
-	update-alternatives --install /usr/bin/mips64-linux-gnuabi64-gcc mips64-linux-gnuabi64-gcc /usr/bin/mips64-linux-gnuabi64-gcc-5 999 && \
-	update-alternatives --install /usr/bin/mips64-linux-gnuabi64-g++ mips64-linux-gnuabi64-g++ /usr/bin/mips64-linux-gnuabi64-g++-5 999 && \
-	update-alternatives --install /usr/bin/arm-linux-gnueabihf-gcc arm-linux-gnueabihf-gcc /usr/bin/arm-linux-gnueabihf-gcc-5 999 && \
-	update-alternatives --install /usr/bin/arm-linux-gnueabihf-g++ arm-linux-gnueabihf-g++ /usr/bin/arm-linux-gnueabihf-g++-5 999 && \
-	update-alternatives --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-gcc-5 999 && \
-	update-alternatives --install /usr/bin/aarch64-linux-gnu-g++ aarch64-linux-gnu-g++ /usr/bin/aarch64-linux-gnu-g++-5 999 && \
+RUN apt-get update && \ 
+	apt-get -y install g++-multilib build-essential && \
+    apt-get -y --no-install-recommends install make cmake xz-utils git clang-6.0 && \
+    apt-get install g++-5-arm-linux-gnueabihf -y && \
+    rm -f /usr/bin/arm-linux-gnueabihf-gcc && \
+    rm -f /usr/bin/arm-linux-gnueabihf-g++ && \
+    ln -s arm-linux-gnueabihf-gcc-5 /usr/bin/arm-linux-gnueabihf-gcc && \
+    ln -s arm-linux-gnueabihf-g++-5 /usr/bin/arm-linux-gnueabihf-g++ && \
+	apt-get install g++-5-aarch64-linux-gnu -y && \
+    rm -f /usr/bin/aarch64-linux-gnu-gcc && \
+	rm -f /usr/bin/aarch64-linux-gnu-g++ && \
+	ln -s aarch64-linux-gnu-gcc-5 /usr/bin/aarch64-linux-gnu-gcc && \
+	ln -s aarch64-linux-gnu-g++-5 /usr/bin/aarch64-linux-gnu-g++ && \
+	apt-get install g++-5-mips-linux-gnu -y && \
+	rm -f /usr/bin/mips-linux-gnu-gcc && \
+	rm -f /usr/bin/mips-linux-gnu-g++ && \
+	ln -s mips-linux-gnu-gcc-5 /usr/bin/mips-linux-gnu-gcc && \
+	ln -s mips-linux-gnu-g++-5 /usr/bin/mips-linux-gnu-g++ && \
+	apt-get install g++-5-mips64-linux-gnuabi64 -y && \
+	rm -f /usr/bin/mips64-linux-gnuabi64-gcc && \
+	rm -f /usr/bin/mips64-linux-gnuabi64-g++ && \
+	ln -s mips64-linux-gnuabi64-gcc-5 /usr/bin/mips64-linux-gnuabi64-gcc && \
+	ln -s mips64-linux-gnuabi64-g++-5 /usr/bin/mips64-linux-gnuabi64-g++ && \
 	ln -s x86_64-linux-gnu /usr/include/i386-linux-gnu && \
 	ln -s x86_64-linux-gnu /usr/include/x86_64-linux-gnux32 && \
-	apt-get -y install g++-multilib && \
+	update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 999 && \
+	update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-6.0 999 && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/* && \
 	rm -rf /usr/share/doc && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,46 +1,23 @@
-FROM ubuntu:14.04
+FROM ubuntu:xenial
 
 MAINTAINER ngot "https://github.com/ngot"
 
-RUN apt-get update
-RUN apt-get install software-properties-common -y
-RUN add-apt-repository 'deb http://us.archive.ubuntu.com/ubuntu/ xenial main restricted universe multiverse' && \
-add-apt-repository 'deb http://us.archive.ubuntu.com/ubuntu/ xenial-updates main restricted universe multiverse' && \
-add-apt-repository 'deb http://us.archive.ubuntu.com/ubuntu/ xenial-backports main restricted universe multiverse' && \
-add-apt-repository 'deb http://security.ubuntu.com/ubuntu xenial-security main restricted universe multiverse'
-
-RUN apt-get update
-RUN apt-get install curl g++ make cmake git g++-multilib -y
-RUN rm -f /usr/include/asm
-RUN ln -s x86_64-linux-gnu /usr/include/i386-linux-gnu
-RUN ln -s x86_64-linux-gnu /usr/include/x86_64-linux-gnux32
-
-RUN apt-get install g++-5-arm-linux-gnueabihf -y
-RUN rm -f /usr/bin/arm-linux-gnueabihf-gcc
-RUN rm -f /usr/bin/arm-linux-gnueabihf-g++
-RUN ln -s arm-linux-gnueabihf-gcc-5 /usr/bin/arm-linux-gnueabihf-gcc
-RUN ln -s arm-linux-gnueabihf-g++-5 /usr/bin/arm-linux-gnueabihf-g++
-
-RUN apt-get install g++-5-aarch64-linux-gnu -y
-RUN rm -f /usr/bin/aarch64-linux-gnu-gcc
-RUN rm -f /usr/bin/aarch64-linux-gnu-g++
-RUN ln -s aarch64-linux-gnu-gcc-5 /usr/bin/aarch64-linux-gnu-gcc
-RUN ln -s aarch64-linux-gnu-g++-5 /usr/bin/aarch64-linux-gnu-g++
-
-RUN apt-get install g++-5-mips-linux-gnu -y
-RUN rm -f /usr/bin/mips-linux-gnu-gcc
-RUN rm -f /usr/bin/mips-linux-gnu-g++
-RUN ln -s mips-linux-gnu-gcc-5 /usr/bin/mips-linux-gnu-gcc
-RUN ln -s mips-linux-gnu-g++-5 /usr/bin/mips-linux-gnu-g++
-
-RUN apt-get install g++-5-mips64-linux-gnuabi64 -y
-RUN rm -f /usr/bin/mips64-linux-gnuabi64-gcc
-RUN rm -f /usr/bin/mips64-linux-gnuabi64-g++
-RUN ln -s mips64-linux-gnuabi64-gcc-5 /usr/bin/mips64-linux-gnuabi64-gcc
-RUN ln -s mips64-linux-gnuabi64-g++-5 /usr/bin/mips64-linux-gnuabi64-g++
-
-RUN apt-get install g++-5-arm-linux-gnueabihf -y
-RUN rm -f /usr/bin/arm-linux-gnueabihf-gcc
-RUN rm -f /usr/bin/arm-linux-gnueabihf-g++
-RUN ln -s arm-linux-gnueabihf-gcc-5 /usr/bin/arm-linux-gnueabihf-gcc
-RUN ln -s arm-linux-gnueabihf-g++-5 /usr/bin/arm-linux-gnueabihf-g++
+RUN apt-get update && \
+    apt-get -y --no-install-recommends install make cmake xz-utils git clang-6.0 g++-5-mips-linux-gnu g++-5-mips64-linux-gnuabi64 g++-5-powerpc-linux-gnu g++-5-powerpc64-linux-gnu g++-5-arm-linux-gnueabihf g++-5-aarch64-linux-gnu && \
+    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 999 && \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-6.0 999 && \
+    update-alternatives --install /usr/bin/mips-linux-gnu-gcc mips-linux-gnu-gcc /usr/bin/mips-linux-gnu-gcc-5 999 && \
+	update-alternatives --install /usr/bin/mips-linux-gnu-g++ mips-linux-gnu-g++ /usr/bin/mips-linux-gnu-g++-5 999 && \
+	update-alternatives --install /usr/bin/mips64-linux-gnuabi64-gcc mips64-linux-gnuabi64-gcc /usr/bin/mips64-linux-gnuabi64-gcc-5 999 && \
+	update-alternatives --install /usr/bin/mips64-linux-gnuabi64-g++ mips64-linux-gnuabi64-g++ /usr/bin/mips64-linux-gnuabi64-g++-5 999 && \
+	update-alternatives --install /usr/bin/arm-linux-gnueabihf-gcc arm-linux-gnueabihf-gcc /usr/bin/arm-linux-gnueabihf-gcc-5 999 && \
+	update-alternatives --install /usr/bin/arm-linux-gnueabihf-g++ arm-linux-gnueabihf-g++ /usr/bin/arm-linux-gnueabihf-g++-5 999 && \
+	update-alternatives --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-gcc-5 999 && \
+	update-alternatives --install /usr/bin/aarch64-linux-gnu-g++ aarch64-linux-gnu-g++ /usr/bin/aarch64-linux-gnu-g++-5 999 && \
+	ln -s x86_64-linux-gnu /usr/include/i386-linux-gnu && \
+	ln -s x86_64-linux-gnu /usr/include/x86_64-linux-gnux32 && \
+	apt-get -y install g++-multilib && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/* && \
+	rm -rf /usr/share/doc && \
+	rm -rf /usr/share/man


### PR DESCRIPTION
- 1.镜像升级到16.04
- 2.链式安装，减小镜像层数
- 3.安装clang-6.0和其他相关的包
